### PR TITLE
Adiciona quebra de texto dado um limite

### DIFF
--- a/src/TextWrap/Resolucao.php
+++ b/src/TextWrap/Resolucao.php
@@ -27,7 +27,7 @@ class Resolucao implements TextWrapInterface {
     if (empty($text)) {
       return [""];
     }
-    
+
     $retorno = [];
     $palavras = explode(" ", $text);
 

--- a/src/TextWrap/Resolucao.php
+++ b/src/TextWrap/Resolucao.php
@@ -24,7 +24,7 @@ class Resolucao implements TextWrapInterface {
    * testes unitários.
    */
   public function textWrap(string $text, int $length): array {
-    if (empty($text)) {
+    if (empty($text) || $length < 1) {
       return [""];
     }
 

--- a/src/TextWrap/Resolucao.php
+++ b/src/TextWrap/Resolucao.php
@@ -24,25 +24,23 @@ class Resolucao implements TextWrapInterface {
    * testes unitários.
    */
   public function textWrap(string $text, int $length): array {
-    $retorno= array();
-    $palavras = explode(" ",$text);
-    $retorno = array();
+    $retorno = [];
+    $palavras = explode(" ", $text);
 
     if (empty($text)) {
       return $retorno;
     }
 
-    foreach($palavras as $palavra){          
-      $textoNovo="";
-
+    foreach ($palavras as $palavra) {
       if (mb_strlen($palavra, "UTF-8") <= $length) {
-        if(empty($retorno)) {
+        if (empty($retorno)) { 
           array_push($retorno, $palavra);
-        } else {
+        } 
+        else {
           $contador = count($retorno) - 1;
           $textoNovo = $retorno[$contador] . " " . $palavra;
 
-          if(mb_strlen($textoNovo, "UTF-8") <= $length) {
+          if (mb_strlen($textoNovo, "UTF-8") <= $length) {
             $retorno[$contador] = $textoNovo;
           } else {
             array_push($retorno, $palavra);
@@ -50,10 +48,10 @@ class Resolucao implements TextWrapInterface {
         }
       }
       else {
-        while(mb_strlen ($palavra, "UTF-8") > $length) {
+        while (mb_strlen ($palavra, "UTF-8") > $length) {
           $palavraQuebrada = substr($palavra, 0, $length);
           array_push($retorno, $palavraQuebrada);
-          $palavra = substr($palavra,$length);
+          $palavra = substr($palavra, $length);
         }
 
         array_push($retorno, $palavra);

--- a/src/TextWrap/Resolucao.php
+++ b/src/TextWrap/Resolucao.php
@@ -33,22 +33,23 @@ class Resolucao implements TextWrapInterface {
 
     foreach ($palavras as $palavra) {
       if (mb_strlen($palavra, "UTF-8") <= $length) {
-        if (empty($retorno)) { 
+        if (empty($retorno)) {
           array_push($retorno, $palavra);
-        } 
+        }
         else {
           $contador = count($retorno) - 1;
           $textoNovo = $retorno[$contador] . " " . $palavra;
 
           if (mb_strlen($textoNovo, "UTF-8") <= $length) {
             $retorno[$contador] = $textoNovo;
-          } else {
+          }
+          else {
             array_push($retorno, $palavra);
           }
         }
       }
       else {
-        while (mb_strlen ($palavra, "UTF-8") > $length) {
+        while (mb_strlen($palavra, "UTF-8") > $length) {
           $palavraQuebrada = substr($palavra, 0, $length);
           array_push($retorno, $palavraQuebrada);
           $palavra = substr($palavra, $length);

--- a/src/TextWrap/Resolucao.php
+++ b/src/TextWrap/Resolucao.php
@@ -24,44 +24,43 @@ class Resolucao implements TextWrapInterface {
    * testes unitários.
    */
   public function textWrap(string $text, int $length): array {
-    if ($length === 8) {
-      return [
-        'Se vi',
-        'mais',
-        'longe',
-        'foi por',
-        'estar de',
-        'pé sobre',
-        'ombros',
-        'de',
-        'gigantes',
-      ];
-    }
-    elseif ($length === 12) {
-      return [
-        'Se vi mais',
-        'longe foi',
-        'por estar de',
-        'pé sobre',
-        'ombros de',
-        'gigantes',
-      ];
-    }
-    elseif ($length === 10) {
-      // Por favor, não implemente o código desse jeito, isso é só um mock.
-      $ret = [
-        'Se vi mais',
-        'longe foi',
-        'por estar',
-        'de pé',
-        'sobre',
-      ];
-      $ret[] = 'ombros de';
-      $ret[] = 'gigantes';
-      return $ret;
+    $retorno= array();
+    $palavras = explode(" ",$text);
+    $retorno = array();
+
+    if (empty($text)) {
+      return $retorno;
     }
 
-    return [""];
+    foreach($palavras as $palavra){          
+      $textoNovo="";
+
+      if (mb_strlen($palavra, "UTF-8") <= $length) {
+        if(empty($retorno)) {
+          array_push($retorno, $palavra);
+        } else {
+          $contador = count($retorno) - 1;
+          $textoNovo = $retorno[$contador] . " " . $palavra;
+
+          if(mb_strlen($textoNovo, "UTF-8") <= $length) {
+            $retorno[$contador] = $textoNovo;
+          } else {
+            array_push($retorno, $palavra);
+          }
+        }
+      }
+      else {
+        while(mb_strlen ($palavra, "UTF-8") > $length) {
+          $palavraQuebrada = substr($palavra, 0, $length);
+          array_push($retorno, $palavraQuebrada);
+          $palavra = substr($palavra,$length);
+        }
+
+        array_push($retorno, $palavra);
+      }
+    }
+
+    return $retorno;
   }
 
 }

--- a/src/TextWrap/Resolucao.php
+++ b/src/TextWrap/Resolucao.php
@@ -24,12 +24,12 @@ class Resolucao implements TextWrapInterface {
    * testes unitários.
    */
   public function textWrap(string $text, int $length): array {
+    if (empty($text)) {
+      return [""];
+    }
+    
     $retorno = [];
     $palavras = explode(" ", $text);
-
-    if (empty($text)) {
-      return $retorno;
-    }
 
     foreach ($palavras as $palavra) {
       if (mb_strlen($palavra, "UTF-8") <= $length) {

--- a/tests/src/Unit/TextWrapTest.php
+++ b/tests/src/Unit/TextWrapTest.php
@@ -88,4 +88,15 @@ class TextWrapTest extends TestCase {
     $this->assertCount(12, $ret);
   }
 
+  /**
+   * Checa o retorno para tamanho inválido.
+   *
+   * @covers Galoa\ExerciciosPhp\TextWrap\Resolucao::textWrap
+   */
+  public function testForEmptyStrings() {
+    $ret = $this->resolucao->textWrap("$this->baseString", 0);
+    $this->assertEmpty($ret[0]);
+    $this->assertCount(1, $ret);
+  }
+
 }

--- a/tests/src/Unit/TextWrapTest.php
+++ b/tests/src/Unit/TextWrapTest.php
@@ -66,4 +66,26 @@ class TextWrapTest extends TestCase {
     $this->assertCount(6, $ret);
   }
 
+  /**
+   * Testa quebra de linha para palavras maior do que o limite.
+   *
+   * @covers Galoa\ExerciciosPhp\TextWrap\Resolucao::textWrap
+   */
+  public function testForWordsWithSizeGraterThanLimit() {
+    $ret = $this->resolucao->textWrap($this->baseString, 6);
+    $this->assertEquals("Se vi", $ret[0]);
+    $this->assertEquals("mais", $ret[1]);
+    $this->assertEquals("longe", $ret[2]);
+    $this->assertEquals("foi", $ret[3]);
+    $this->assertEquals("por", $ret[4]);
+    $this->assertEquals("estar", $ret[5]);
+    $this->assertEquals("de pé", $ret[6]);
+    $this->assertEquals("sobre", $ret[7]);
+    $this->assertEquals("ombros", $ret[8]);
+    $this->assertEquals("de", $ret[9]);
+    $this->assertEquals("gigant", $ret[10]);
+    $this->assertEquals("es", $ret[11]);
+    $this->assertCount(12, $ret);
+  }
+
 }

--- a/tests/src/Unit/TextWrapTest.php
+++ b/tests/src/Unit/TextWrapTest.php
@@ -93,7 +93,7 @@ class TextWrapTest extends TestCase {
    *
    * @covers Galoa\ExerciciosPhp\TextWrap\Resolucao::textWrap
    */
-  public function testForEmptyStrings() {
+  public function testForInvalidLength() {
     $ret = $this->resolucao->textWrap("$this->baseString", 0);
     $this->assertEmpty($ret[0]);
     $this->assertCount(1, $ret);


### PR DESCRIPTION
# Descrição
- Implementa função para quebra de um texto grande baseado em um limite

# Teste
- Ao chamar a função `textWrap` com o parametro `text=" Inconstitucionalissimamente"` e `length=6` é esperado o seguinte retorno:
  - [
  	0 => "Incons"
  	1 => "tituci"
  	2 => "onalis"
  	3 => "simame"
  	4 => "nte"
  ]

- Ao chamar a função `textWrap` com o parametro `text="Se vi mais longe foi por estar de pé sobre ombros de gigantes"` e `length=8` é esperado o seguinte retorno:

  - [
    0 => "Se vi"
    1 => "mais"
    2 => "longe"
    3 => " foi por"
    4 => "estar de"
    5 => " pé sobre"
    6 => "ombros"
    7 => "de"
    8 => "gigantes"
  ]

  - Ao chamar a função `textWrap` com o parametro `text=""` e `length=1` é esperado o seguinte retorno:

  - [""]

 - Ao chamar a função `textWrap` com o parametro `text="Se vi mais longe foi por estar de pé sobre ombros de gigantes"` e `length=0` é esperado o seguinte retorno:

   - [""]



